### PR TITLE
fix: geist font loads properly

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -100,21 +100,7 @@
     }
 
     body {
-        @apply bg-background text-foreground;
-    }
-
-    @font-face {
-        font-family: "geist";
-        font-style: normal;
-        font-weight: 100 900;
-        src: url(/fonts/geist.woff2) format("woff2");
-    }
-
-    @font-face {
-        font-family: "geist-mono";
-        font-style: normal;
-        font-weight: 100 900;
-        src: url(/fonts/geist-mono.woff2) format("woff2");
+        @apply bg-background text-foreground font-sans;
     }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+const defaultTheme = require('tailwindcss/defaultTheme')
 
 export default {
     darkMode: ["class"],
@@ -65,7 +66,17 @@ export default {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
-  		}
+  		},
+			fontFamily: {
+				sans: [
+          'Geist',
+          ...defaultTheme.fontFamily.sans,
+        ],
+				mono:[
+					'Geist_Mono',
+					...defaultTheme.fontFamily.mono
+				]
+			}
   	}
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
I assume we want to use **geist font sans serif** as a default, added variable for the mono font also, could be fun to add a feature to let load their own font from the UI.